### PR TITLE
Replace 'login' and 'logout' with 'log in' and 'log out'

### DIFF
--- a/html.js
+++ b/html.js
@@ -146,7 +146,7 @@ export const RootBody = ({ rooms, whoIsInTheHub, personalizations }) => {
     </dl>
 
     <hl />
-    <p>You're logged in! - <a href="/logout">logout</a></p>
+    <p>You're logged in! - <a href="/logout">log out</a></p>
   `;
 
   body += html`</main>`;
@@ -298,7 +298,7 @@ export const Login = ({ reason } = { reason: "" }) => html`
           happens frequently.
         </p>`
       : ""}
-    <p><a hx-boost="false" href="/getAuthorizationUrl">Login</a></p>
+    <p><a hx-boost="false" href="/getAuthorizationUrl">Log in</a></p>
   </main>
 `;
 


### PR DESCRIPTION
This PR replaces "login" -> "log in", and "logout" -> "log out" on `html.js`, since in both cases, they're being used as verbs.

(I haven't tried compiling/running this to see if it breaks anything, but I'm fairly confident it doesn't)